### PR TITLE
[[ BUG 8181 ]] Move a File to Trash or Recycle Bin

### DIFF
--- a/docs/dictionary/command/delete-file.lcdoc
+++ b/docs/dictionary/command/delete-file.lcdoc
@@ -40,7 +40,7 @@ answer file "Choose a file to Trash:"
 put it into tName
 switch (the platform)
  case "MacOS"
- --on OS X the Trash is ~/.Trash/ so all you need to do is rename your file to '/.Trash/fileToTrash.
+ --on OS X the Trash is ~/.Trash/ so all you need to do is rename your file to '~/.Trash/fileToTrash'.
   put tName into tNameTrash
   set the itemDel to "/"
   put "~/.Trash" into item 1 to -2 of tNameTrash

--- a/docs/dictionary/command/delete-file.lcdoc
+++ b/docs/dictionary/command/delete-file.lcdoc
@@ -32,7 +32,31 @@ Use the <delete file> <command> to clean up by removing a <file> you created.
 
 This command can also be used to remove files your stack did not create. Of course, a stack should not remove files and folders it did not create without obtaining explicit confirmation from the user.
 
->*Warning:* This <command> cannot be undone, so be very certain before you use it. The <delete file> <command> removes the file completely from the user's system. It does not place the file in the Trash or Recycle Bin.
+>*Warning:* This <command> cannot be undone, so be very certain before you use it. The <delete file> <command> removes the file completely from the user's system. It does not place the file in the Trash or Recycle Bin. To place a file in the Trash or Recycle Bin use the following example.
+
+Example:
+local tName, tNameTrash
+answer file "Choose a file to Trash:"
+put it into tName
+switch (the platform)
+ case "MacOS"
+ --on OS X the Trash is ~/.Trash/ so all you need to do is rename your file to '/.Trash/fileToTrash.
+  put tName into tNameTrash
+  set the itemDel to "/"
+  put "~/.Trash" into item 1 to -2 of tNameTrash
+  rename file tName to tNameTrash
+ break
+ case "Win32"
+ --on Windows VBScript is required to move a file to the Recycle Bin*/
+  replace "/" with "\" in tName
+  put "Const RECYCLE_BIN = &Ha&" & cr & \
+  "Set objShell = CreateObject(`Shell.Application`)" & cr & \
+  "Set recycleFolder = objShell.NameSpace(RECYCLE_BIN)" & cr & \
+  "recycleFolder.MoveHere `" & tName & "`" into tScript
+  replace "`" with quote in tScript
+  do tScript as "VBScript"
+ break
+end switch
 
 >*Note:* iOS imposes strict controls over what you can and cannot access. Each application in iOS is stored in its own 'sandbox' folder (referred to as the home folder). An application is free to read and write files within this folder and its descendants, but it is not allowed to access anything outside of the 'sandbox'.
 


### PR DESCRIPTION
Added a sentence to the end of the Warniing + the accompanying example.

NOTE: I've only tested the code for OS X as I do not have a Windows machine. The VB script was extracted from the Use List and dates back to 2008 so verification that it is still valid is required. Sorry, my research for Linux indicated that the Trash location changed with distribution and/or windowing environment so no Linux example is given.

Bug 8181 refers to a Caution for both delete file and delete folder but no such Caution (now Warning) exists in the current documents for delete folder - nor should one exist as you can only delete an empty folder with this command. I therefore see no need to add an example of how to move an empty folder to the Trash or Recycle Bin. I intend to add an example of how to move a 'full' folder to the Trash for the revDeleteFolder command; at which point bug 8181 should be closed.
