### PR TITLE
[[BUG 15176]] Corrected reference to Trash on OS X

### DIFF
--- a/docs/dictionary/command/revDeleteFolder.lcdoc
+++ b/docs/dictionary/command/revDeleteFolder.lcdoc
@@ -21,12 +21,12 @@ revDeleteFolder myTempFolder
 Parameters:
 folderToDelete: The folderToDelete specifies the name and location of the folder. If you specify a name but not a location, LiveCode assumes the folder is in the defaultFolder.
 
-The result: The <revDeleteFolder> <command> uses system services on each <platform> to perform the move. On <Mac OS> and <OS X|OS X systems>, it uses <AppleScript>; on <Windows> and <Unix> systems, it uses the <shell> <function>. Any errors encountered are <return|returned> in the <result> <function>.
+The result: The <revDeleteFolder> <command> uses system services on each <platform> to perform the move. On <OS X|OS X systems>, it uses <AppleScript>; on <Windows> and <Unix> systems, it uses the <shell> <function>. Any errors encountered are <return|returned> in the <result> <function>.
 
 Description:
 Use the <revDeleteFolder> <function> to remove a <folder> from the disk.
 
-The <revDeleteFolder> <command> removes the entire <folder>, including all <file|files>, <subfolder|subfolders>, and their contents. Alternatively, to place a folder in the Trash or Recycle Bin use the following example.
+The <revDeleteFolder> <command> removes the entire <folder>, including all <file|files>, <subfolder|subfolders>, and their contents. Alternatively, to place a <folder> in the Trash or Recycle Bin use the following example.
 +
 +Example:
 +local tName, tNameTrash
@@ -52,8 +52,8 @@ The <revDeleteFolder> <command> removes the entire <folder>, including all <file
 + break
 +end switch
 
->*Warning:*  This <command> can be used to rename or move <file|files> and <folder|folders> your stack did not create. Of course, a <stack> should not rename or move <file|files> and <folder|folders> it didn't create without obtaining explicit confirmation from the user.
+>*Warning:*  This <command> can be used to <rename> or move <file|files> and <folder|folders> your <stack> did not create. Of course, a <stack> should not <rename> or move <file|files> and <folder|folders> it didn't create without obtaining explicit confirmation from the user.
 
->*Note:* When included in a <standalone application>, the <Common library> is implemented as a hidden <group> and made available when the <group> receives its first <openBackground> message. During the first part of the <application|application's> startup process, before this <message> is sent, the <revDeleteFolder> <command> is not yet available. This may affect attempts to use this <command> in <startup>, <preOpenStack>, <openStack>, or <preOpenCard> <handler|handlers> in the <main stack>. Once the <application> has finished starting up, the <library> is available and the <revDeleteFolder> <command> can be used in any <handler>.
+>*Note:* When included in a <standalone application>, the <Common library> is implemented as a hidden <group> and made available when the <group> receives its first <openBackground> <message>. During the first part of the <application|application's> startup process, before this <message> is sent, the <revDeleteFolder> <command> is not yet available. This may affect attempts to use this <command> in <startup>, <preOpenStack>, <openStack>, or <preOpenCard> <handler|handlers> in the <main stack>. Once the <application> has finished starting up, the <library> is available and the <revDeleteFolder> <command> can be used in any <handler>.
 
-References: startup (message), openBackground (message), preOpenStack (message), openStack (message), preOpenCard (message), Common library (library), library (library), function (control_st), application (glossary), return (glossary), standalone application (glossary), file (glossary), shell (glossary), subfolder (glossary), platform (glossary), command (glossary), Windows (glossary), main stack (glossary), OS X (glossary), AppleScript (glossary), group (glossary), result (glossary), Unix (glossary), Mac OS (glossary), folder (glossary), message (glossary), handler (glossary), folders (function), revCopyFolder (command), create folder (command), answer folder (command), delete file (command), revMoveFolder (command), stack (object)
+References: startup (message), openBackground (message), preOpenStack (message), openStack (message), preOpenCard (message), Common library (library), library (library), function (control_st), application (glossary), return (glossary), standalone application (glossary), file (glossary), folder (glossary), shell (glossary), subfolder (glossary), platform (glossary), command (glossary), Windows (glossary), main stack (glossary), OS X (glossary), AppleScript (glossary), group (glossary), result (glossary), Unix (glossary), Mac OS (glossary), folder (glossary), message (glossary), handler (glossary), folders (function), revCopyFolder (command), create folder (command), answer folder (command), delete file (command), revMoveFolder (command), rename (command), stack (object)

--- a/docs/dictionary/command/revDeleteFolder.lcdoc
+++ b/docs/dictionary/command/revDeleteFolder.lcdoc
@@ -26,9 +26,31 @@ The result: The <revDeleteFolder> <command> uses system services on each <platfo
 Description:
 Use the <revDeleteFolder> <function> to remove a <folder> from the disk.
 
-The <revDeleteFolder> <command> removes the entire <folder>, including all <file|files>, <subfolder|subfolders>, and their contents.
-
-On Mac OS and OS X systems, the <revDeleteFolder> <command> places the <folder> in the Trash.
+The <revDeleteFolder> <command> removes the entire <folder>, including all <file|files>, <subfolder|subfolders>, and their contents. Alternatively, to place a folder in the Trash or Recycle Bin use the following example.
++
++Example:
++local tName, tNameTrash
++answer folder "Choose a folder to Trash:"
++put it into tName
++switch (the platform)
++ case "MacOS"
++ --on OS X the Trash is ~/.Trash/ so all you need to do is rename your folder to '~/.Trash/folderToTrash'.
++  put tName into tNameTrash
++  set the itemDel to "/"
++  put "~/.Trash" into item 1 to -2 of tNameTrash
++  rename folder tName to tNameTrash
++ break
++ case "Win32"
++ --on Windows VBScript is required to move a folder to the Recycle Bin
++  replace "/" with "\" in tName
++  put "Const RECYCLE_BIN = &Ha&" & cr & \
++  "Set objShell = CreateObject(`Shell.Application`)" & cr & \
++  "Set recycleFolder = objShell.NameSpace(RECYCLE_BIN)" & cr & \
++  "recycleFolder.MoveHere `" & tName & "`" into tScript
++  replace "`" with quote in tScript
++  do tScript as "VBScript"
++ break
++end switch
 
 >*Warning:*  This <command> can be used to rename or move <file|files> and <folder|folders> your stack did not create. Of course, a <stack> should not rename or move <file|files> and <folder|folders> it didn't create without obtaining explicit confirmation from the user.
 


### PR DESCRIPTION
BUG 15176 confirms that on OS X the revDeleteFolder is a permenant delete - as per other platforms. Removed the incorrect statement indicating on OS X the folder was trashed.

BUG 8181 requests an example on how to safely move folders to the Trash. Added an example on how to do that. The OS X example has been tested. I do not have a Windows machine, the Windows example was extracted from the Use List and dates back to 2008 so needs verification.

My search on the Use List indicated the Trash on Linux was fluid, dependent of distribution and windowing system so no Linux example is given.

I have a pull request for 'delete file' which also is in relation to BUG 8181. Once both these pull requests are merged BUG 8181 can also be closed.
